### PR TITLE
Initial version of handling multiple WireMock instances, add common test methods

### DIFF
--- a/src/main/java/io/knotx/junit5/KnotxConverters.java
+++ b/src/main/java/io/knotx/junit5/KnotxConverters.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 
 import io.knotx.dataobjects.Fragment;
 import io.knotx.fragments.SnippetPatterns;
+import io.knotx.junit5.util.FileReader;
 import io.knotx.options.SnippetOptions;
 import io.vertx.core.json.JsonObject;
 import java.io.IOException;
@@ -53,7 +54,7 @@ class KnotxConverters {
     final String[] params = fragmentParameters.split(PARAMETER_SEPARATOR_REGEX);
     final String fragmentContentFile = params[0];
     final String snippetTagName = extractSnippetTagName(params);
-    final String fragmentContent = KnotxTestUtils.readText(fragmentContentFile);
+    final String fragmentContent = FileReader.readText(fragmentContentFile);
     final String snippetParamPrefix = extractSnippetParamPrefix(params, fragmentParameters);
     final SnippetPatterns patterns =
         new SnippetPatterns(buildOptions(snippetTagName, snippetParamPrefix));

--- a/src/main/java/io/knotx/junit5/KnotxExtension.java
+++ b/src/main/java/io/knotx/junit5/KnotxExtension.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 
 /**
  * Support for field and parameter injection for Knot.x tests <br>
@@ -63,7 +64,8 @@ public class KnotxExtension extends KnotxBaseExtension
     AfterTestExecutionCallback,
     BeforeTestExecutionCallback,
     AfterAllCallback,
-    BeforeAllCallback {
+    BeforeAllCallback,
+    TestInstancePostProcessor {
 
   private static final long DEFAULT_TIMEOUT_SECONDS = 30;
   private static final String VERTX_INSTANCE_STORE_KEY = "VertxInstance";
@@ -104,7 +106,12 @@ public class KnotxExtension extends KnotxBaseExtension
 
   @Override
   public void beforeAll(ExtensionContext context) throws Exception {
-    wiremockExtension.beforeAll(context);
+  }
+
+  @Override
+  public void postProcessTestInstance(Object testInstance, ExtensionContext context)
+      throws Exception {
+    wiremockExtension.postProcessTestInstance(testInstance, context);
   }
 
   @Override

--- a/src/main/java/io/knotx/junit5/KnotxTestUtils.java
+++ b/src/main/java/io/knotx/junit5/KnotxTestUtils.java
@@ -31,6 +31,7 @@ public class KnotxTestUtils {
    * Read contents of resource and return as string. Ported from
    * io.knotx.junit.util.FileReader.readText(String) and fixed.
    *
+   * @deprecated use {@linkplain FileReader#readText(String)} instead
    * @param path resource path
    * @return resource contents
    * @throws IOException resource can not be read

--- a/src/main/java/io/knotx/junit5/KnotxTestUtils.java
+++ b/src/main/java/io/knotx/junit5/KnotxTestUtils.java
@@ -15,16 +15,17 @@
  */
 package io.knotx.junit5;
 
-import com.google.common.io.Resources;
+import io.knotx.junit5.util.FileReader;
+import io.knotx.junit5.util.RequestUtil;
 import io.reactivex.Observable;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.reactivex.core.http.HttpClient;
 import io.vertx.reactivex.core.http.HttpClientRequest;
 import io.vertx.reactivex.core.http.HttpClientResponse;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 
+@Deprecated
 public class KnotxTestUtils {
 
   /**
@@ -36,19 +37,11 @@ public class KnotxTestUtils {
    * @throws IOException resource can not be read
    */
   public static String readText(String path) throws IOException {
-    return Resources.toString(Resources.getResource(path), StandardCharsets.UTF_8);
+    return FileReader.readText(path);
   }
 
   /**
-   * Generate reactivex async request for given resource parameters
-   *
-   * @param client Vert.x client
-   * @param method target HTTP method
-   * @param port target port
-   * @param domain target domain
-   * @param uri resource to request
-   * @param requestBuilder handler for request body and params
-   * @return reactivex wrapper
+   * Use this instead: {@linkplain RequestUtil#asyncRequest(HttpClient, HttpMethod, int, String, String, Consumer)}
    */
   public static Observable<HttpClientResponse> asyncRequest(
       HttpClient client,
@@ -57,13 +50,6 @@ public class KnotxTestUtils {
       String domain,
       String uri,
       Consumer<HttpClientRequest> requestBuilder) {
-    return Observable.unsafeCreate(
-        subscriber -> {
-          HttpClientRequest request = client.request(method, port, domain, uri);
-          Observable<HttpClientResponse> resp = request.toObservable();
-          resp.subscribe(subscriber);
-          requestBuilder.accept(request);
-          request.end();
-        });
+    return RequestUtil.asyncRequest(client, method, port, domain, uri, requestBuilder);
   }
 }

--- a/src/main/java/io/knotx/junit5/util/FileReader.java
+++ b/src/main/java/io/knotx/junit5/util/FileReader.java
@@ -15,18 +15,31 @@
  */
 package io.knotx.junit5.util;
 
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 public interface FileReader {
 
+  /**
+   * Read contents of resource and return as string. Ported from
+   * io.knotx.junit.util.FileReader.readText(String) and fixed.
+   *
+   * @param path resource path
+   * @return resource contents
+   * @throws IOException resource can not be read
+   */
   static String readText(String path) throws IOException {
-    return CharStreams
-        .toString(new InputStreamReader(Resources.getResource(path).openStream(), "utf-8"));
+    return Resources.toString(Resources.getResource(path), StandardCharsets.UTF_8);
   }
 
+  /**
+   * Same as {@linkplain #readText(String)}, but throws unchecked exception instead
+   *
+   * @param path resource path
+   * @return resource contents
+   * @throws IllegalArgumentException on IOException
+   */
   static String readTextSafe(String path) {
     try {
       return readText(path);
@@ -34,5 +47,4 @@ public interface FileReader {
       throw new IllegalArgumentException("Could not load text from [" + path + "]");
     }
   }
-
 }

--- a/src/main/java/io/knotx/junit5/util/RequestUtil.java
+++ b/src/main/java/io/knotx/junit5/util/RequestUtil.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2018 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.junit5.util;
+
+import io.knotx.dataobjects.ClientResponse;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import io.reactivex.functions.Consumer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.reactivex.core.http.HttpClient;
+import io.vertx.reactivex.core.http.HttpClientRequest;
+import io.vertx.reactivex.core.http.HttpClientResponse;
+
+public interface RequestUtil {
+  /**
+   * Generate reactivex async request for given resource parameters
+   *
+   * @param client Vert.x client
+   * @param method target HTTP method
+   * @param port target port
+   * @param domain target domain
+   * @param uri resource to request
+   * @param requestBuilder handler for request body and params
+   * @return reactivex wrapper
+   */
+  static Observable<HttpClientResponse> asyncRequest(
+      HttpClient client,
+      HttpMethod method,
+      int port,
+      String domain,
+      String uri,
+      java.util.function.Consumer<HttpClientRequest> requestBuilder) {
+    return Observable.unsafeCreate(
+        subscriber -> {
+          HttpClientRequest request = client.request(method, port, domain, uri);
+          Observable<HttpClientResponse> resp = request.toObservable();
+          resp.subscribe(subscriber);
+          requestBuilder.accept(request);
+          request.end();
+        });
+  }
+
+  /**
+   * Safely execute onError handler on given result, passing checks to given test context
+   *
+   * @param context test context
+   * @param result to which subscribe
+   * @param onError result handler, can throw exceptions
+   */
+  static void subscribeToResult_shouldFail(
+      VertxTestContext context, Single<ClientResponse> result, Consumer<Throwable> onError) {
+    result
+        .doOnError(onError)
+        .subscribe(
+            response -> context.failNow(new IllegalStateException("Error should occur")),
+            error -> context.completeNow());
+  }
+
+  /**
+   * Safely execute onSuccess handler on given result, passing checks to given test context
+   *
+   * @param context test context
+   * @param result to which subscribe
+   * @param onSuccess result handler, can throw exceptions
+   */
+  static void subscribeToResult_shouldSucceed(
+      VertxTestContext context, Single<ClientResponse> result, Consumer<ClientResponse> onSuccess) {
+    result
+        .doOnSuccess(onSuccess)
+        .subscribe(
+            response -> context.completeNow(), context::failNow);
+  }
+
+  static <T> void processWithContextVerification(
+      VertxTestContext context, Consumer<T> consumer, T consummable) {
+    context.verify(
+        () -> {
+          try {
+            consumer.accept(consummable);
+
+            context.completeNow();
+          } catch (Exception e) {
+            context.failNow(e);
+          }
+        });
+  }
+}

--- a/src/main/java/io/knotx/junit5/util/RequestUtil.java
+++ b/src/main/java/io/knotx/junit5/util/RequestUtil.java
@@ -15,7 +15,6 @@
  */
 package io.knotx.junit5.util;
 
-import io.knotx.dataobjects.ClientResponse;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Consumer;
@@ -61,8 +60,8 @@ public interface RequestUtil {
    * @param result to which subscribe
    * @param onError result handler, can throw exceptions
    */
-  static void subscribeToResult_shouldFail(
-      VertxTestContext context, Single<ClientResponse> result, Consumer<Throwable> onError) {
+  static <T> void subscribeToResult_shouldFail(
+      VertxTestContext context, Single<T> result, Consumer<Throwable> onError) {
     result
         .doOnError(onError)
         .subscribe(
@@ -77,8 +76,8 @@ public interface RequestUtil {
    * @param result to which subscribe
    * @param onSuccess result handler, can throw exceptions
    */
-  static void subscribeToResult_shouldSucceed(
-      VertxTestContext context, Single<ClientResponse> result, Consumer<ClientResponse> onSuccess) {
+  static <T> void subscribeToResult_shouldSucceed(
+      VertxTestContext context, Single<T> result, Consumer<T> onSuccess) {
     result
         .doOnSuccess(onSuccess)
         .subscribe(

--- a/src/main/java/io/knotx/junit5/util/RequestUtil.java
+++ b/src/main/java/io/knotx/junit5/util/RequestUtil.java
@@ -21,6 +21,9 @@ import io.vertx.junit5.VertxTestContext;
 
 public final class RequestUtil {
 
+  /** Util class - no instantiation */
+  private RequestUtil() {}
+
   /**
    * Safely execute onError handler on given result, passing checks to given test context
    *

--- a/src/main/java/io/knotx/junit5/util/RequestUtil.java
+++ b/src/main/java/io/knotx/junit5/util/RequestUtil.java
@@ -19,7 +19,7 @@ import io.reactivex.Single;
 import io.reactivex.functions.Consumer;
 import io.vertx.junit5.VertxTestContext;
 
-public interface RequestUtil {
+public final class RequestUtil {
 
   /**
    * Safely execute onError handler on given result, passing checks to given test context
@@ -29,7 +29,7 @@ public interface RequestUtil {
    * @param onError result handler, can throw exceptions
    * @param <T> result type to process, irrelevant here
    */
-  static <T> void subscribeToResult_shouldFail(
+  public static <T> void subscribeToResult_shouldFail(
       VertxTestContext context, Single<T> result, Consumer<Throwable> onError) {
     result
         .doOnError(onError)
@@ -46,7 +46,7 @@ public interface RequestUtil {
    * @param assertions result handler, can throw exceptions
    * @param <T> result type to process, assertions must accept the same type
    */
-  static <T> void subscribeToResult_shouldSucceed(
+  public static <T> void subscribeToResult_shouldSucceed(
       VertxTestContext context, Single<T> result, Consumer<T> assertions) {
     result.doOnSuccess(assertions).subscribe(response -> context.completeNow(), context::failNow);
   }
@@ -60,7 +60,7 @@ public interface RequestUtil {
    * @param consummable object to process
    * @param <T> type of consummable to process
    */
-  static <T> void processWithContextVerification(
+  public static <T> void processWithContextVerification(
       VertxTestContext context, Consumer<T> consumer, T consummable) {
     context.verify(
         () -> {

--- a/src/main/java/io/knotx/junit5/wiremock/KnotxFileSource.java
+++ b/src/main/java/io/knotx/junit5/wiremock/KnotxFileSource.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.junit5.wiremock;
+
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.Response;
+import io.knotx.junit5.util.FileReader;
+import org.apache.commons.lang3.StringUtils;
+
+/** Fix for WireMock's inability to deliver files from resources without appending various info */
+class KnotxFileSource extends ResponseTransformer {
+
+  @Override
+  public Response transform(
+      Request request, Response response, FileSource files, Parameters parameters) {
+    String requestPath = request.getUrl();
+    requestPath = StringUtils.removeStart(requestPath, "/");
+
+    String body = FileReader.readTextSafe(requestPath);
+
+    return Response.Builder.like(response).body(body).build();
+  }
+
+  @Override
+  public String getName() {
+    return "knotx-wiremock-source-changer";
+  }
+}

--- a/src/main/java/io/knotx/junit5/wiremock/KnotxWiremockExtension.java
+++ b/src/main/java/io/knotx/junit5/wiremock/KnotxWiremockExtension.java
@@ -48,7 +48,7 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
       "WiremockServerInstancesMap";
 
   private static final ReentrantLock wiremockMapLock = new ReentrantLock(true);
-  private static final WiremockMap wiremockMap = new WiremockMap();
+  private static final HashMap<Integer, WireMock> wiremockMap = new HashMap<>();
 
   /**
    * Retrieve Wiremock for given port and add given mappings
@@ -183,6 +183,7 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
     }
 
     WireMockConfiguration config = new WireMockConfiguration();
+    config.extensions(new KnotxFileSource());
 
     if (port == Options.DYNAMIC_PORT) {
       config.dynamicPort();
@@ -234,8 +235,6 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
         o -> new WiremockServerMap(),
         WiremockServerMap.class);
   }
-
-  private static class WiremockMap extends HashMap<Integer, WireMock> {}
 
   private class WiremockServerMap extends HashMap<Integer, WireMockServer> {}
 }

--- a/src/main/java/io/knotx/junit5/wiremock/KnotxWiremockExtension.java
+++ b/src/main/java/io/knotx/junit5/wiremock/KnotxWiremockExtension.java
@@ -161,18 +161,21 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
   }
 
   private static WireMock getOrCreateWiremock(int port) {
-    if (wiremockMap.containsKey(port)) {
-      return wiremockMap.get(port);
+    try {
+      wiremockMapLock.lock();
+
+      if (wiremockMap.containsKey(port)) {
+        return wiremockMap.get(port);
+      }
+
+      WireMock instance = new WireMock("localhost", port);
+
+      wiremockMap.put(port, instance);
+
+      return instance;
+    } finally {
+      wiremockMapLock.unlock();
     }
-
-    wiremockMapLock.lock();
-
-    WireMock instance = new WireMock("localhost", port);
-    wiremockMap.put(port, instance);
-
-    wiremockMapLock.unlock();
-
-    return instance;
   }
 
   /** Cleanup known Wiremock instances */

--- a/src/main/java/io/knotx/junit5/wiremock/KnotxWiremockExtension.java
+++ b/src/main/java/io/knotx/junit5/wiremock/KnotxWiremockExtension.java
@@ -30,25 +30,49 @@ import java.util.Optional;
 import java.util.concurrent.locks.ReentrantLock;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 
 /**
  * Manages {@linkplain WireMockServer} instances for parameter and field injection. Standalone
  * extension, can be used separately from {@linkplain KnotxExtension}.
  */
 public class KnotxWiremockExtension extends KnotxBaseExtension
-    implements ParameterResolver, BeforeAllCallback, AfterAllCallback, AfterEachCallback {
+    implements ParameterResolver, TestInstancePostProcessor, AfterAllCallback, AfterEachCallback {
 
   private static final String WIREMOCK_SERVER_INSTANCES_MAP_STORE_KEY =
       "WiremockServerInstancesMap";
 
   private static final ReentrantLock wiremockMapLock = new ReentrantLock(true);
   private static final WiremockMap wiremockMap = new WiremockMap();
+
+  /**
+   * Retrieve Wiremock for given port and add given mappings
+   *
+   * @see WireMock#stubFor(MappingBuilder)
+   * @param port on which server is configured
+   * @param mappingBuilder given mapping
+   * @return created mapping
+   */
+  public static StubMapping stubForPort(int port, MappingBuilder mappingBuilder) {
+    return getOrCreateWiremock(port).register(mappingBuilder);
+  }
+
+  /**
+   * Add given mappings for this server
+   *
+   * @see WireMock#stubFor(MappingBuilder)
+   * @param server to which add mapping
+   * @param mappingBuilder given mapping
+   * @return created mapping
+   */
+  public static StubMapping stubForServer(WireMockServer server, MappingBuilder mappingBuilder) {
+    return stubForPort(server.port(), mappingBuilder);
+  }
 
   @Override
   public boolean supportsParameter(
@@ -91,12 +115,14 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
 
   @Override
   public void afterAll(ExtensionContext context) throws Exception {
-    cleanupWiremock(context);
+    cleanupWiremockServers(context);
+    shutdownWiremock();
   }
 
   /** Sets up all annotated fields in test class */
   @Override
-  public void beforeAll(ExtensionContext context) throws Exception {
+  public void postProcessTestInstance(Object testInstance, ExtensionContext context)
+      throws Exception {
     Optional<Class<?>> testClass = context.getTestClass();
     if (!testClass.isPresent()) {
       return;
@@ -108,7 +134,7 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
         .filter(
             field ->
                 field.isAnnotationPresent(KnotxWiremock.class)
-                    && field.getDeclaringClass().equals(WireMockServer.class))
+                    && field.getType().equals(WireMockServer.class))
         .forEach(
             field -> {
               Store store = getStore(context);
@@ -117,8 +143,8 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
 
               field.setAccessible(true);
               try {
-                field.set(WireMockServer.class.newInstance(), server);
-              } catch (IllegalAccessException | InstantiationException e) {
+                field.set(testInstance, server);
+              } catch (IllegalAccessException | IllegalArgumentException e) {
                 throw new RuntimeException(
                     "Could not inject wiremock server into requested field", e);
               }
@@ -127,11 +153,25 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
 
   @Override
   public void afterEach(ExtensionContext context) throws Exception {
-    cleanupWiremock(context);
+    cleanupWiremockServers(context);
   }
 
-  public static StubMapping stubForPort(int port, MappingBuilder mappingBuilder) {
-    return getOrCreateWiremock(port).register(mappingBuilder);
+  private static WireMock getOrCreateWiremock(int port) {
+    try {
+      wiremockMapLock.lock();
+
+      if (wiremockMap.containsKey(port)) {
+        return wiremockMap.get(port);
+      }
+
+      WireMock instance = new WireMock("localhost", port);
+
+      wiremockMap.put(port, instance);
+
+      return instance;
+    } finally {
+      wiremockMapLock.unlock();
+    }
   }
 
   private WireMockServer setupWiremockServer(KnotxWiremock knotxWiremock, Store store) {
@@ -160,26 +200,8 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
     return server;
   }
 
-  private static WireMock getOrCreateWiremock(int port) {
-    try {
-      wiremockMapLock.lock();
-
-      if (wiremockMap.containsKey(port)) {
-        return wiremockMap.get(port);
-      }
-
-      WireMock instance = new WireMock("localhost", port);
-
-      wiremockMap.put(port, instance);
-
-      return instance;
-    } finally {
-      wiremockMapLock.unlock();
-    }
-  }
-
   /** Cleanup known Wiremock instances */
-  private void cleanupWiremock(ExtensionContext context) {
+  private void cleanupWiremockServers(ExtensionContext context) {
     Store store = getStore(context);
     WiremockServerMap instancesMap = getWiremockServerMap(store);
 
@@ -191,12 +213,13 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
                 if (server.isRunning()) {
                   server.resetRequests();
                   server.resetToDefaultMappings();
-                  server.stop();
                 }
               });
       instancesMap.clear();
     }
+  }
 
+  private void shutdownWiremock() {
     wiremockMapLock.lock();
 
     wiremockMap.values().forEach(WireMock::shutdown);
@@ -212,7 +235,7 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
         WiremockServerMap.class);
   }
 
-  private class WiremockServerMap extends HashMap<Integer, WireMockServer> {}
-
   private static class WiremockMap extends HashMap<Integer, WireMock> {}
+
+  private class WiremockServerMap extends HashMap<Integer, WireMockServer> {}
 }


### PR DESCRIPTION
And KnotxTestUtils gets deprecated in favor of more modular approach.