### PR TITLE
Allow for Knot.x config overrides when using dynamic (random) ports

### DIFF
--- a/src/main/java/io/knotx/junit5/HoconConcatConfigProcessor.java
+++ b/src/main/java/io/knotx/junit5/HoconConcatConfigProcessor.java
@@ -1,0 +1,78 @@
+package io.knotx.junit5;
+
+import static io.vertx.config.impl.spi.PropertiesConfigProcessor.closeQuietly;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigRenderOptions;
+import io.vertx.config.spi.ConfigProcessor;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class HoconConcatConfigProcessor implements ConfigProcessor {
+
+  @Override
+  public String name() {
+    return "knotx";
+  }
+
+  @Override
+  public void process(
+      Vertx vertx,
+      JsonObject configuration,
+      Buffer input,
+      Handler<AsyncResult<JsonObject>> handler) {
+    vertx.executeBlocking(
+        future -> {
+          JsonArray paths = configuration.getJsonArray("paths");
+          JsonObject overrides = configuration.getJsonObject("overrides");
+
+          // readers are stored in order of overriding - base first, overrides last
+          ArrayList<Reader> readers = new ArrayList<>(4);
+          try {
+            // load user configurations
+            for (Object o : paths) {
+              String path = String.valueOf(o);
+              String value = vertx.fileSystem().readFileBlocking(path).toString();
+
+              readers.add(new StringReader(value));
+            }
+
+            // add overrides
+            readers.add(new StringReader(overrides.encode()));
+
+            // put overrides first
+            Collections.reverse(readers);
+
+            Config fullConfig = ConfigFactory.empty();
+
+            for (Reader reader : readers) {
+              fullConfig = fullConfig.withFallback(ConfigFactory.parseReader(reader));
+            }
+
+            // and render everything
+            fullConfig = fullConfig.resolve();
+            ConfigRenderOptions options =
+                ConfigRenderOptions.concise().setJson(true).setComments(false).setFormatted(false);
+            String output = fullConfig.root().render(options);
+
+            future.complete(new JsonObject(output));
+          } catch (Exception e) {
+            future.fail(e);
+          } finally {
+            for (Reader reader : readers) {
+              closeQuietly(reader);
+            }
+          }
+        },
+        handler);
+  }
+}

--- a/src/main/java/io/knotx/junit5/KnotxExtension.java
+++ b/src/main/java/io/knotx/junit5/KnotxExtension.java
@@ -34,7 +34,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -64,7 +63,6 @@ public class KnotxExtension extends KnotxBaseExtension
     AfterTestExecutionCallback,
     BeforeTestExecutionCallback,
     AfterAllCallback,
-    BeforeAllCallback,
     TestInstancePostProcessor {
 
   private static final long DEFAULT_TIMEOUT_SECONDS = 30;
@@ -102,10 +100,6 @@ public class KnotxExtension extends KnotxBaseExtension
     }
 
     return vertxExtension.resolveParameter(parameterContext, extensionContext);
-  }
-
-  @Override
-  public void beforeAll(ExtensionContext context) throws Exception {
   }
 
   @Override
@@ -250,7 +244,7 @@ public class KnotxExtension extends KnotxBaseExtension
   }
 
   private DeploymentOptions createConfig(String[] paths) {
-    JsonObject storesConfig = new ConfigRetrieverOptions()
+    ConfigRetrieverOptions configRetrieverOptions = new ConfigRetrieverOptions()
         .setStores(
             Stream.of(paths)
                 .map(path ->
@@ -259,8 +253,11 @@ public class KnotxExtension extends KnotxBaseExtension
                         .setFormat(getConfigFormat(path))
                         .setConfig(new JsonObject().put("path", path)))
                 .collect(Collectors.toList())
-        )
-        .toJson();
+        );
+
+    //todo add overrides from wiremock ext
+
+    JsonObject storesConfig = configRetrieverOptions.toJson();
     return new DeploymentOptions()
         .setConfig(
             new JsonObject()

--- a/src/main/java/io/knotx/junit5/wiremock/KnotxFileSource.java
+++ b/src/main/java/io/knotx/junit5/wiremock/KnotxFileSource.java
@@ -42,11 +42,9 @@ class KnotxFileSource extends ResponseTransformer {
           "json", "application/json",
           "txt", "text/plain");
 
-  private KnotxMockConfig config;
   private boolean autodetectMime;
 
-  public KnotxFileSource(KnotxMockConfig knotxMockConfig) {
-    config = knotxMockConfig;
+  public KnotxFileSource(KnotxMockConfig config) {
     autodetectMime = KnotxMockConfig.MIMETYPE_AUTODETECT.equals(config.mimetype);
   }
 

--- a/src/main/java/io/knotx/junit5/wiremock/KnotxFileSource.java
+++ b/src/main/java/io/knotx/junit5/wiremock/KnotxFileSource.java
@@ -18,16 +18,37 @@ package io.knotx.junit5.wiremock;
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.Response;
 import com.github.tomakehurst.wiremock.http.Response.Builder;
+import com.google.common.collect.ImmutableMap;
 import io.knotx.junit5.util.FileReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Map;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /** Fix for WireMock's inability to deliver files from resources without appending various info */
 class KnotxFileSource extends ResponseTransformer {
+
+  private static final String CHARSET_APPEND = "; charset=UTF-8";
+
+  private static Map<String, String> extensionMapping =
+      ImmutableMap.of(
+          "html", "text/html",
+          "json", "application/json",
+          "txt", "text/plain");
+
+  private KnotxMockConfig config;
+  private boolean autodetectMime;
+
+  public KnotxFileSource(KnotxMockConfig knotxMockConfig) {
+    config = knotxMockConfig;
+    autodetectMime = KnotxMockConfig.MIMETYPE_AUTODETECT.equals(config.mimetype);
+  }
 
   @Override
   public Response transform(
@@ -40,11 +61,25 @@ class KnotxFileSource extends ResponseTransformer {
       throw new IllegalStateException("Malformed request URL", e);
     }
 
+    Builder builder = Builder.like(response);
+
+    if (autodetectMime) {
+      String extension = FilenameUtils.getExtension(requestPath);
+      String mime = extensionMapping.get(extension);
+
+      if (StringUtils.isNotBlank(mime)) {
+        mime += CHARSET_APPEND;
+        builder.headers(
+            HttpHeaders.copyOf(response.getHeaders())
+                .plus(HttpHeader.httpHeader("Content-Type", mime)));
+      }
+    }
+
     requestPath = StringUtils.removeStart(requestPath, "/");
 
     String body = FileReader.readTextSafe(requestPath);
 
-    return Builder.like(response).body(body).build();
+    return builder.body(body).build();
   }
 
   @Override

--- a/src/main/java/io/knotx/junit5/wiremock/KnotxMockConfig.java
+++ b/src/main/java/io/knotx/junit5/wiremock/KnotxMockConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2018 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.junit5.wiremock;
+
+import com.github.tomakehurst.wiremock.core.Options;
+
+class KnotxMockConfig {
+  public static final String MIMETYPE_AUTODETECT = "!autodetect";
+  public static final String PATH_INHERIT = "!inherit";
+  public static final int RANDOM_PORT = Options.DYNAMIC_PORT;
+
+  final String name;
+  final int port;
+  final String requestPath;
+  final String mimetype;
+
+  public KnotxMockConfig(String name, int port, String requestPath, String mimetype) {
+    this.name = name;
+    this.port = port;
+    this.requestPath = requestPath;
+    this.mimetype = mimetype;
+  }
+
+  public KnotxMockConfig(String name, int port, String requestPath) {
+    this.name = name;
+    this.port = port;
+    this.requestPath = requestPath;
+    this.mimetype = MIMETYPE_AUTODETECT;
+  }
+
+  public KnotxMockConfig(String name, int port) {
+    this.name = name;
+    this.port = port;
+    this.requestPath = PATH_INHERIT;
+    this.mimetype = MIMETYPE_AUTODETECT;
+  }
+
+  public KnotxMockConfig(String name) {
+    this.name = name;
+    this.port = RANDOM_PORT;
+    this.requestPath = PATH_INHERIT;
+    this.mimetype = MIMETYPE_AUTODETECT;
+  }
+}

--- a/src/main/java/io/knotx/junit5/wiremock/KnotxMockConfig.java
+++ b/src/main/java/io/knotx/junit5/wiremock/KnotxMockConfig.java
@@ -23,35 +23,42 @@ class KnotxMockConfig {
   public static final int RANDOM_PORT = Options.DYNAMIC_PORT;
 
   final String name;
-  final int port;
   final String requestPath;
   final String mimetype;
+  final int port;
 
-  public KnotxMockConfig(String name, int port, String requestPath, String mimetype) {
+  KnotxMockConfig(String name, int port, String requestPath, String mimetype) {
     this.name = name;
     this.port = port;
     this.requestPath = requestPath;
     this.mimetype = mimetype;
   }
 
-  public KnotxMockConfig(String name, int port, String requestPath) {
+  KnotxMockConfig(String name, int port, String requestPath) {
     this.name = name;
     this.port = port;
     this.requestPath = requestPath;
     this.mimetype = MIMETYPE_AUTODETECT;
   }
 
-  public KnotxMockConfig(String name, int port) {
+  KnotxMockConfig(String name, int port) {
     this.name = name;
     this.port = port;
     this.requestPath = PATH_INHERIT;
     this.mimetype = MIMETYPE_AUTODETECT;
   }
 
-  public KnotxMockConfig(String name) {
+  KnotxMockConfig(String name) {
     this.name = name;
     this.port = RANDOM_PORT;
     this.requestPath = PATH_INHERIT;
     this.mimetype = MIMETYPE_AUTODETECT;
+  }
+
+  KnotxMockConfig(KnotxMockConfig parent, int newPort) {
+    this.name = parent.name;
+    this.port = newPort;
+    this.requestPath = parent.requestPath;
+    this.mimetype = parent.mimetype;
   }
 }

--- a/src/main/java/io/knotx/junit5/wiremock/KnotxWiremockExtension.java
+++ b/src/main/java/io/knotx/junit5/wiremock/KnotxWiremockExtension.java
@@ -219,6 +219,7 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
     wiremockServerMap.forEach((port, server) -> server.shutdown());
     wiremockServerMap.clear();
     wiremockMap.clear();
+    serviceNamePortMap.clear();
 
     try { //FIXME: REMOVE THIS BULLSHIT
       Thread.sleep(500);

--- a/src/main/java/io/knotx/junit5/wiremock/KnotxWiremockExtension.java
+++ b/src/main/java/io/knotx/junit5/wiremock/KnotxWiremockExtension.java
@@ -111,16 +111,13 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
   }
 
   @Override
-  public void afterAll(ExtensionContext context) throws Exception {
+  public void afterAll(ExtensionContext context) {
     shutdownWiremock();
   }
 
-  /**
-   * Sets up all annotated fields in test class
-   */
+  /** Sets up all annotated fields in test class */
   @Override
-  public void postProcessTestInstance(Object testInstance, ExtensionContext context)
-      throws Exception {
+  public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
     Optional<Class<?>> testClass = context.getTestClass();
     if (!testClass.isPresent()) {
       return;
@@ -178,7 +175,7 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
     try {
       wiremockMapLock.lock();
 
-      //rule: same name == same config, so was created before
+      // rule: same name == same config, so was created before
       if (serviceNamePortMap.containsKey(name)) {
         return wiremockServerMap.get(serviceNamePortMap.get(name).port);
       }
@@ -215,16 +212,11 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
   private void shutdownWiremock() {
     wiremockMapLock.lock();
 
-    //calling WireMock.shutdown() would shutdown only the default instance
+    // calling WireMock.shutdown() would shutdown only the default instance
     wiremockServerMap.forEach((port, server) -> server.shutdown());
     wiremockServerMap.clear();
     wiremockMap.clear();
     serviceNamePortMap.clear();
-
-    try { //FIXME: REMOVE THIS BULLSHIT
-      Thread.sleep(500);
-    } catch (InterruptedException ignore) {
-    }
 
     wiremockMapLock.unlock();
   }
@@ -237,17 +229,13 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
 
       serviceNamePortMap.values().forEach(
           config -> serversConfig.put(config.name,
-              ImmutableMap.of("port", config.port)));
+              ImmutableMap.of("port", config.port))
+      );
     } finally {
       wiremockMapLock.unlock();
     }
 
-    Map<String, Object> map =
-        ImmutableMap.of("test",
-            ImmutableMap.of("wiremock",
-                serversConfig
-            )
-        );
+    Map<String, Object> map = ImmutableMap.of("test", ImmutableMap.of("wiremock", serversConfig));
     return new JsonObject(map);
   }
 }

--- a/src/main/java/io/knotx/junit5/wiremock/KnotxWiremockExtension.java
+++ b/src/main/java/io/knotx/junit5/wiremock/KnotxWiremockExtension.java
@@ -20,16 +20,17 @@ import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import com.google.common.collect.ImmutableMap;
 import io.knotx.junit5.KnotxBaseExtension;
 import io.knotx.junit5.KnotxExtension;
 import io.vertx.core.json.JsonObject;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.locks.ReentrantLock;
 import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
@@ -41,20 +42,20 @@ import org.junit.jupiter.api.extension.TestInstancePostProcessor;
  * extension, can be used separately from {@linkplain KnotxExtension}.
  */
 public class KnotxWiremockExtension extends KnotxBaseExtension
-    implements ParameterResolver, TestInstancePostProcessor, AfterAllCallback, AfterEachCallback {
+    implements ParameterResolver, TestInstancePostProcessor, AfterAllCallback {
 
   private static final ReentrantLock wiremockMapLock = new ReentrantLock(true);
   private static final HashMap<Integer, WireMock> wiremockMap = new HashMap<>();
   private static final HashMap<Integer, WireMockServer> wiremockServerMap = new HashMap<>();
-  private static final HashMap<String, Integer> serviceNamePortMap = new HashMap<>();
+  private static final HashMap<String, KnotxMockConfig> serviceNamePortMap = new HashMap<>();
 
   /**
    * Retrieve Wiremock for given port and add given mappings
    *
-   * @see WireMock#stubFor(MappingBuilder)
    * @param port on which server is configured
    * @param mappingBuilder given mapping
    * @return created mapping
+   * @see WireMock#stubFor(MappingBuilder)
    */
   public static StubMapping stubForPort(int port, MappingBuilder mappingBuilder) {
     return getOrCreateWiremock(port).register(mappingBuilder);
@@ -63,10 +64,10 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
   /**
    * Add given mappings for this server
    *
-   * @see WireMock#stubFor(MappingBuilder)
    * @param server to which add mapping
    * @param mappingBuilder given mapping
    * @return created mapping
+   * @see WireMock#stubFor(MappingBuilder)
    */
   public static StubMapping stubForServer(WireMockServer server, MappingBuilder mappingBuilder) {
     return stubForPort(server.port(), mappingBuilder);
@@ -114,7 +115,9 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
     shutdownWiremock();
   }
 
-  /** Sets up all annotated fields in test class */
+  /**
+   * Sets up all annotated fields in test class
+   */
   @Override
   public void postProcessTestInstance(Object testInstance, ExtensionContext context)
       throws Exception {
@@ -143,10 +146,6 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
                     "Could not inject wiremock server into requested field", e);
               }
             });
-  }
-
-  @Override
-  public void afterEach(ExtensionContext context) throws Exception {
   }
 
   private static WireMock getOrCreateWiremock(int port) {
@@ -181,7 +180,7 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
 
       //rule: same name == same config, so was created before
       if (serviceNamePortMap.containsKey(name)) {
-        return wiremockServerMap.get(serviceNamePortMap.get(name));
+        return wiremockServerMap.get(serviceNamePortMap.get(name).port);
       }
 
       if (wiremockServerMap.containsKey(port)) {
@@ -201,10 +200,11 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
       server.start();
 
       port = server.port();
+      config = new KnotxMockConfig(config, port);
       getOrCreateWiremock(port);
 
       wiremockServerMap.put(port, server);
-      serviceNamePortMap.put(name, port);
+      serviceNamePortMap.put(name, config);
 
       return server;
     } finally {
@@ -222,13 +222,31 @@ public class KnotxWiremockExtension extends KnotxBaseExtension
 
     try { //FIXME: REMOVE THIS BULLSHIT
       Thread.sleep(500);
-    } catch (InterruptedException ignore) {}
+    } catch (InterruptedException ignore) {
+    }
 
     wiremockMapLock.unlock();
   }
 
   public JsonObject getConfigOverrides() {
+    Map<String, Object> serversConfig = new HashMap<>();
 
-    return null;
+    try {
+      wiremockMapLock.lock();
+
+      serviceNamePortMap.values().forEach(
+          config -> serversConfig.put(config.name,
+              ImmutableMap.of("port", config.port)));
+    } finally {
+      wiremockMapLock.unlock();
+    }
+
+    Map<String, Object> map =
+        ImmutableMap.of("test",
+            ImmutableMap.of("wiremock",
+                serversConfig
+            )
+        );
+    return new JsonObject(map);
   }
 }

--- a/src/main/resources/META-INF/services/io.vertx.config.spi.ConfigProcessor
+++ b/src/main/resources/META-INF/services/io.vertx.config.spi.ConfigProcessor
@@ -1,0 +1,1 @@
+io.knotx.junit5.HoconConcatConfigProcessor

--- a/src/main/resources/META-INF/services/io.vertx.config.spi.ConfigProcessor
+++ b/src/main/resources/META-INF/services/io.vertx.config.spi.ConfigProcessor
@@ -1,1 +1,1 @@
-io.knotx.junit5.HoconConcatConfigProcessor
+io.knotx.junit5.KnotxConcatConfigProcessor


### PR DESCRIPTION
- Allow hierarchical Knot.x configuration usage in tests
- Add config object for all mocks (`KnotxMockConfig`)

**Potential breaking changes**
1. See `KnotxConfigConcatProcessor` and `KnotxExtension.createConfig(String[])`. This fixes problems found in https://github.com/Knotx/knotx-stack/pull/19, but at the same time changes Knot.x configuration loading behavior. Configuration files will now be loaded into memory, overrides from `KnotxWiremockExtension` will be applied, and resulting configuration will be provided *in-memory* to `KnotxStarterVerticle`. This has a potential to omit some internal logic and assumptions, as found earlier in https://github.com/Cognifide/knotx/pull/440.
2. Instances of WireMockServer are now recognized by their mock name (be it a field name or parameter name), and as such these names currently have to be unique across all tests. So if two tests use the same mock named `mockRepository` and run simultaneously, then the mock instance will be reused for both tests, regardless of possible configuration differences between test mocks. Good examples are integration tests in https://github.com/Knotx/knotx-stack/pull/19.