### PR TITLE
Bugfix for being unable to resolve mock port due to mock server name mismatch

### DIFF
--- a/src/main/java/io/knotx/junit5/KnotxBaseExtension.java
+++ b/src/main/java/io/knotx/junit5/KnotxBaseExtension.java
@@ -30,4 +30,8 @@ public abstract class KnotxBaseExtension {
   protected Store getStore(ExtensionContext extensionContext) {
     return extensionContext.getStore(Namespace.create(this.getClass(), extensionContext));
   }
+
+  protected String getClassName(ExtensionContext extensionContext) {
+    return extensionContext.getTestClass().orElseThrow(IllegalStateException::new).getName();
+  }
 }


### PR DESCRIPTION
This properly enables mocks to be used per test class instead of previous rule that all names must be unique across all tests, fixes issue with previous PR.