### PR TITLE
Update to JUnit 5.3.1, cleanup due to BOM update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ defaultTasks = ['build']
 dependencyManagement {
   imports {
     mavenBom 'io.knotx:knotx-dependencies:1.3.1-SNAPSHOT'
-    mavenBom 'org.junit:junit-bom:5.2.0'
+    mavenBom 'org.junit:junit-bom:5.3.1'
   }
 }
 
@@ -46,12 +46,11 @@ dependencies {
   compile 'org.junit.jupiter:junit-jupiter-params'
   compile 'org.junit.jupiter:junit-jupiter-migrationsupport'
 
-  /* Versions are hardcoded due to how Maven BOM scopes work
-   * Mockito and Wiremock are set to 'test' in BOM, but here
-   * we need to compile against them */
-  compile 'org.mockito:mockito-core:2.21.0'
-  compile 'org.mockito:mockito-junit-jupiter:2.21.0'
-  compile 'com.github.tomakehurst:wiremock:2.17.0'
+  compile 'org.mockito:mockito-core'
+  compile 'org.mockito:mockito-junit-jupiter'
+  compile 'com.github.tomakehurst:wiremock'
+
+  compile 'me.alexpanov:free-port-finder'
 }
 
 test {


### PR DESCRIPTION
Prerequisite: https://github.com/Knotx/knotx-dependencies/pull/9 has to get merged and snapshotted first