### PR TITLE
Gradle publishing to maven local repository should not require signing.

### DIFF
--- a/release.gradle
+++ b/release.gradle
@@ -91,7 +91,7 @@ publishing {
 }
 
 signing {
-  required { gradle.taskGraph.hasTask(tasks.publish) }
+  required { gradle.taskGraph.hasTask(tasks.publish) || gradle.taskGraph.hasTask(tasks.publishMavenJavaPublicationToMavenRepository) }
   sign publishing.publications.mavenJava
 }
 


### PR DESCRIPTION
Gradle publishing to maven local repository should not require signing.

## Description
Gradle publishing to maven local repository should not require signing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
