### PR TITLE
Html Markup Assertion to test html body content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to `knotx-junit5` will be documented in this file.
 
 ## Unreleased
-List of changes that are finished but not yet released in any final version.
+- [PR-5](https://github.com/Knotx/knotx-junit5) - Html Markup Assertion to test html body content
 
 ## 1.4.0
 Initial open source release.

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ dependencies {
 
   compile 'me.alexpanov:free-port-finder'
   compile 'commons-io:commons-io'
+  compile 'org.jsoup:jsoup'
 }
 
 test {

--- a/src/main/java/io/knotx/junit5/assertions/HtmlMarkupAssertions.java
+++ b/src/main/java/io/knotx/junit5/assertions/HtmlMarkupAssertions.java
@@ -1,0 +1,64 @@
+package io.knotx.junit5.assertions;
+
+import static java.lang.Character.isWhitespace;
+
+import java.nio.charset.StandardCharsets;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Entities;
+import org.jsoup.parser.Parser;
+import org.junit.jupiter.api.Assertions;
+
+public final class HtmlMarkupAssertions {
+
+  private static final Document.OutputSettings OUTPUT_SETTINGS = new Document.OutputSettings()
+      .escapeMode(Entities.EscapeMode.xhtml)
+      .indentAmount(2)
+      .prettyPrint(true);
+
+  private HtmlMarkupAssertions() {
+    //util class
+  }
+
+  public static void assertHtmlBodyMarkupsEqual(String expectedHtml, String actualHtml) {
+    assertHtmlBodyMarkupsEqual(expectedHtml, actualHtml, null);
+  }
+
+  public static void assertHtmlBodyMarkupsEqual(String expectedHtml, String actualHtml,
+      String message) {
+    final String expectedBodyMarkup = getFormattedBodyOfAFullPage(expectedHtml);
+    final String actualBodyMarkup = getFormattedBodyOfAFullPage(actualHtml);
+    Assertions.assertEquals(expectedBodyMarkup, actualBodyMarkup, message);
+  }
+
+  private static String escapeAndFormat(String expected) {
+    return stripSpace(getFormattedBodyOfAFullPage(expected));
+  }
+
+  private static String getFormattedBodyOfAFullPage(String html) {
+    return Jsoup.parse(html, StandardCharsets.UTF_8.name(), Parser.xmlParser())
+        .outputSettings(OUTPUT_SETTINGS)
+        .body()
+        .html()
+        .trim();
+  }
+
+  private static String stripSpace(String toBeStripped) {
+    final StringBuilder result = new StringBuilder();
+    boolean lastWasSpace = true;
+    for (int i = 0; i < toBeStripped.length(); i++) {
+      char c = toBeStripped.charAt(i);
+      if (isWhitespace(c)) {
+        if (!lastWasSpace) {
+          result.append(' ');
+        }
+        lastWasSpace = true;
+      } else {
+        result.append(c);
+        lastWasSpace = false;
+      }
+    }
+    return result.toString().trim();
+  }
+
+}

--- a/src/main/java/io/knotx/junit5/assertions/HtmlMarkupAssertions.java
+++ b/src/main/java/io/knotx/junit5/assertions/HtmlMarkupAssertions.java
@@ -1,7 +1,5 @@
 package io.knotx.junit5.assertions;
 
-import static java.lang.Character.isWhitespace;
-
 import java.nio.charset.StandardCharsets;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -31,10 +29,6 @@ public final class HtmlMarkupAssertions {
     Assertions.assertEquals(expectedBodyMarkup, actualBodyMarkup, message);
   }
 
-  private static String escapeAndFormat(String expected) {
-    return stripSpace(getFormattedBodyOfAFullPage(expected));
-  }
-
   private static String getFormattedBodyOfAFullPage(String html) {
     return Jsoup.parse(html, StandardCharsets.UTF_8.name(), Parser.xmlParser())
         .outputSettings(OUTPUT_SETTINGS)
@@ -42,23 +36,4 @@ public final class HtmlMarkupAssertions {
         .html()
         .trim();
   }
-
-  private static String stripSpace(String toBeStripped) {
-    final StringBuilder result = new StringBuilder();
-    boolean lastWasSpace = true;
-    for (int i = 0; i < toBeStripped.length(); i++) {
-      char c = toBeStripped.charAt(i);
-      if (isWhitespace(c)) {
-        if (!lastWasSpace) {
-          result.append(' ');
-        }
-        lastWasSpace = true;
-      } else {
-        result.append(c);
-        lastWasSpace = false;
-      }
-    }
-    return result.toString().trim();
-  }
-
 }


### PR DESCRIPTION
## Description
Html Markup Assertion to test html body content

## Motivation and Context
Assertion that can format two html strings and compare them in the HTML comparison way.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
