### PR TITLE
Address crashes on WSL due to free port finding method

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
     implementation(group = "org.mockito", name = "mockito-core")
     implementation(group = "org.mockito", name = "mockito-junit-jupiter")
     implementation(group = "com.github.tomakehurst", name = "wiremock")
-    implementation(group = "me.alexpanov", name = "free-port-finder")
     implementation(group = "commons-io", name = "commons-io")
     implementation(group = "org.jsoup", name = "jsoup", version = "1.11.2")
 

--- a/src/main/java/io/knotx/junit5/KnotxExtension.java
+++ b/src/main/java/io/knotx/junit5/KnotxExtension.java
@@ -17,6 +17,7 @@ package io.knotx.junit5;
 
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
+import io.knotx.junit5.util.FreePortFinder;
 import io.knotx.junit5.wiremock.ClasspathResourcesMockServer;
 import io.knotx.junit5.wiremock.KnotxWiremockExtension;
 import io.vertx.config.ConfigRetrieverOptions;
@@ -44,7 +45,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import me.alexpanov.net.FreePortFinder;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -180,7 +180,7 @@ public class KnotxExtension extends KnotxBaseExtension
       }
 
       try {
-        referenceMapLock.writeLock().lock(); // effectively synchronizing FreePortFinder
+        referenceMapLock.writeLock().lock();
 
         services.forEach(s -> servicePorts.put(s, FreePortFinder.findFreeLocalPort()));
 

--- a/src/main/java/io/knotx/junit5/util/FreePortFinder.java
+++ b/src/main/java/io/knotx/junit5/util/FreePortFinder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.junit5.util;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import org.apache.commons.lang3.RandomUtils;
+
+public class FreePortFinder {
+
+  /** Roll a port number and ensure it's available */
+  public static int findFreeLocalPort() {
+    int port;
+    do {
+      // IANA Ephemeral Port range
+      port = RandomUtils.nextInt(49152, 65535);
+    } while (!isFree(port));
+
+    return port;
+  }
+
+  private synchronized static boolean isFree(int port) {
+    try (ServerSocket ignored = new ServerSocket(port)) {
+      // noop
+    } catch (IOException e) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/main/java/io/knotx/junit5/util/FreePortFinder.java
+++ b/src/main/java/io/knotx/junit5/util/FreePortFinder.java
@@ -27,13 +27,13 @@ public class FreePortFinder {
     do {
       // IANA Ephemeral Port range
       port = RandomUtils.nextInt(49152, 65535);
-    } while (!isFree(port));
+    } while (!available(port));
 
     return port;
   }
 
-  private synchronized static boolean isFree(int port) {
-    try (ServerSocket ignored = new ServerSocket(port)) {
+  public synchronized static boolean available(int port) {
+    try (ServerSocket ignored = new ServerSocket(port, 1)) {
       // noop
     } catch (IOException e) {
       return false;

--- a/src/main/java/io/knotx/junit5/util/FreePortFinder.java
+++ b/src/main/java/io/knotx/junit5/util/FreePortFinder.java
@@ -22,9 +22,14 @@ import org.apache.commons.lang3.RandomUtils;
 public final class FreePortFinder {
 
   /** Util class */
-  private FreePortFinder() {}
+  private FreePortFinder() {
+  }
 
-  /** Roll a port number and ensure it's available */
+  /**
+   * Roll a port number and ensure it's available
+   *
+   * @return port number
+   */
   public static int findFreeLocalPort() {
     int port;
     do {

--- a/src/main/java/io/knotx/junit5/util/FreePortFinder.java
+++ b/src/main/java/io/knotx/junit5/util/FreePortFinder.java
@@ -19,7 +19,10 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import org.apache.commons.lang3.RandomUtils;
 
-public class FreePortFinder {
+public final class FreePortFinder {
+
+  /** Util class */
+  private FreePortFinder() {}
 
   /** Roll a port number and ensure it's available */
   public static int findFreeLocalPort() {

--- a/src/main/java/io/knotx/junit5/wsl/DisabledOnWsl.java
+++ b/src/main/java/io/knotx/junit5/wsl/DisabledOnWsl.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.junit5.wsl;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DisabledOnWslCondition.class)
+public @interface DisabledOnWsl {
+  String value() default "";
+}

--- a/src/main/java/io/knotx/junit5/wsl/DisabledOnWslCondition.java
+++ b/src/main/java/io/knotx/junit5/wsl/DisabledOnWslCondition.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.junit5.wsl;
+
+import java.util.Properties;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Do not use this class directly, instead use the {@linkplain DisabledOnWsl} annotation for
+ * selected test classes or test methods.
+ *
+ * <p>On WSL (Windows Subsystem for Linux) some tests may not be able to function correctly,
+ * resulting in some bad SEGFAULTs or various other errors (due to the fact that WSL is technically
+ * not a full Linux implementation). But some developers want to use WSL anyway, so this condition
+ * allows them to keep their sanity while testing Knot.x functionalities.
+ */
+public class DisabledOnWslCondition implements ExecutionCondition {
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    Properties props = System.getProperties();
+
+    if ("Linux".equals(props.getProperty("os.name"))
+        && props.getProperty("os.version").contains("-Microsoft")) {
+      return ConditionEvaluationResult.disabled(
+          "Windows Subsystem for Linux detected, test disabled");
+    }
+
+    return ConditionEvaluationResult.enabled(
+        "Not running in Windows Subsystem for Linux, test enabled");
+  }
+}

--- a/src/test/java/io/knotx/junit5/util/FreePortFinderTest.java
+++ b/src/test/java/io/knotx/junit5/util/FreePortFinderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.knotx.junit5.util;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/src/test/java/io/knotx/junit5/util/FreePortFinderTest.java
+++ b/src/test/java/io/knotx/junit5/util/FreePortFinderTest.java
@@ -19,8 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.knotx.junit5.wsl.DisabledOnWsl;
 import java.net.ServerSocket;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class FreePortFinderTest {
@@ -33,7 +33,7 @@ class FreePortFinderTest {
   }
 
   @Test
-  @Disabled("Broken on WSL")
+  @DisabledOnWsl("Will pass, even though the port is taken")
   void forRandomPort_whenUsed_mustNotBeAvailable() {
     int port = FreePortFinder.findFreeLocalPort();
 

--- a/src/test/java/io/knotx/junit5/util/FreePortFinderTest.java
+++ b/src/test/java/io/knotx/junit5/util/FreePortFinderTest.java
@@ -1,0 +1,32 @@
+package io.knotx.junit5.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.ServerSocket;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+class FreePortFinderTest {
+
+  @Test
+  void forRandomPort_mustBeAvailable() {
+    int port = FreePortFinder.findFreeLocalPort();
+
+    assertTrue(FreePortFinder.available(port));
+  }
+
+  @Test
+  @Disabled("Broken on WSL")
+  void forRandomPort_whenUsed_mustNotBeAvailable() {
+    int port = FreePortFinder.findFreeLocalPort();
+
+    assertDoesNotThrow(
+        () -> {
+          try (ServerSocket ignore = new ServerSocket(port, 50)) {
+            assertFalse(FreePortFinder.available(port));
+          }
+        });
+  }
+}


### PR DESCRIPTION
## Description
Instead of using external library, switch to a simpler, less exotic way of port checking availability.

## Motivation and Context
Fixes #31, fixes #32

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
