### PR TITLE
Fixed content-type header for ClasspathResourcesMockServer files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to `knotx-junit5` will be documented in this file.
 
 ## Unreleased
+- [PR-39](https://github.com/Knotx/knotx-junit5/pull/39) - Fixed missing content-type header for ClasspathResourcesMockServer files
+
+## 2.0.0
+No notable changes.
+
+## 1.5.0
 - [PR-29](https://github.com/Knotx/knotx-junit5/pull/29) - Add `KnotxAssertions.assertEqualsIgnoreWhitespace`.
 - [PR-28](https://github.com/Knotx/knotx-junit5/pull/28) - Migrate from Gradle 4.X to 5.4.1.
 - [PR-27](https://github.com/Knotx/knotx-junit5/pull/27) - Unit tests for KnotxWiremockExtension, rename `KnotxWiremock` to `ClasspathResourcesMockServer`.

--- a/src/main/java/io/knotx/junit5/wiremock/KnotxFileSource.java
+++ b/src/main/java/io/knotx/junit5/wiremock/KnotxFileSource.java
@@ -69,7 +69,7 @@ class KnotxFileSource extends ResponseTransformer {
       httpHeaders = httpHeaders.plus(header);
     }
 
-    httpHeaders.plus(HttpHeader.httpHeader("Content-Type", mime));
+    httpHeaders = httpHeaders.plus(HttpHeader.httpHeader("Content-Type", mime));
 
     builder.headers(httpHeaders);
 


### PR DESCRIPTION
## Description
Fixed content-type header for ClasspathResourcesMockServer files

## Motivation and Context
Now, `Content-Type` is added as a header for resources in `KnotxWiremockExtension`.
This will fix failing tests for https://github.com/Knotx/knotx-data-bridge/pull/58.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
