### PR TITLE
Move HoconLoader to junit5 utils.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-junit5` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-56](https://github.com/Knotx/knotx-junit5/pull/56) - Move `HoconLoader` from the `Fragments` module to `JUnit5`.
 
 ## 2.1.0
 - [PR-39](https://github.com/Knotx/knotx-junit5/pull/39) - Fixed missing content-type header for ClasspathResourcesMockServer files

--- a/README.md
+++ b/README.md
@@ -188,6 +188,15 @@ For other use cases see following Knot.x projects that use this Knot.x JUnit5 mo
 - [Knot.x HTTP Server](https://github.com/Knotx/knotx-server-http)
 - [Knot.x Data Bridge](https://github.com/Knotx/knotx-data-bridge)
 
+## Utils
+
+### HoconLoader
+[HoconLoader](https://github.com/Knotx/knotx-junit5/blob/master/src/main/java/io/knotx/junit5/util/HoconLoader.java) 
+parses the [HOCON](https://github.com/lightbend/config/blob/master/HOCON.md) configuration 
+files and transforms all entries to JSON. This util is extremely helpful in 
+[Routing Handler](https://github.com/Knotx/knotx-server-http/tree/master/api#routing-handlers)'s 
+contract tests.
+
 ## Bugs
 All feature requests and bugs can be filed as issues on [Gitub](https://github.com/Knotx/knotx-junit5/issues).
 Do not use Github issues to ask questions, post them on the [User Group](https://groups.google.com/forum/#!forum/knotx) or [Gitter Chat](https://gitter.im/Knotx/Lobby).

--- a/src/main/java/io/knotx/junit5/util/HoconLoader.java
+++ b/src/main/java/io/knotx/junit5/util/HoconLoader.java
@@ -15,6 +15,8 @@
  */
 package io.knotx.junit5.util;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.vertx.config.ConfigRetriever;
 import io.vertx.config.ConfigRetrieverOptions;
 import io.vertx.config.ConfigStoreOptions;
@@ -25,7 +27,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import org.junit.jupiter.api.Assertions;
 
 public class HoconLoader {
 
@@ -44,7 +45,7 @@ public class HoconLoader {
         }));
     fromHOCON(fileName, vertx, configHandler);
 
-    Assertions.assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
     if (testContext.failed()) {
       throw testContext.causeOfFailure();
     }
@@ -60,12 +61,10 @@ public class HoconLoader {
       VertxTestContext testContext, Vertx vertx)
       throws Throwable {
     Handler<AsyncResult<JsonObject>> configHandler = testContext
-        .succeeding(config -> testContext.verify(() -> {
-          execution.accept(config);
-        }));
+        .succeeding(config -> testContext.verify(() -> execution.accept(config)));
     fromHOCON(fileName, vertx, configHandler);
 
-    Assertions.assertTrue(testContext.awaitCompletion(5, TimeUnit.MINUTES));
+    assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
     if (testContext.failed()) {
       throw testContext.causeOfFailure();
     }

--- a/src/main/java/io/knotx/junit5/util/HoconLoader.java
+++ b/src/main/java/io/knotx/junit5/util/HoconLoader.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.junit5.util;
+
+import io.vertx.config.ConfigRetriever;
+import io.vertx.config.ConfigRetrieverOptions;
+import io.vertx.config.ConfigStoreOptions;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxTestContext;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Assertions;
+
+public class HoconLoader {
+
+  public static void verify(String fileName, Consumer<JsonObject> assertions,
+      io.vertx.reactivex.core.Vertx vertx) throws Throwable {
+    verify(fileName, assertions, vertx.getDelegate());
+  }
+
+  public static void verify(String fileName, Consumer<JsonObject> assertions, Vertx vertx)
+      throws Throwable {
+    VertxTestContext testContext = new VertxTestContext();
+    Handler<AsyncResult<JsonObject>> configHandler = testContext
+        .succeeding(config -> testContext.verify(() -> {
+          assertions.accept(config);
+          testContext.completeNow();
+        }));
+    fromHOCON(fileName, vertx, configHandler);
+
+    Assertions.assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+  public static void verifyAsync(String fileName, Consumer<JsonObject> execution,
+      VertxTestContext testContext, io.vertx.reactivex.core.Vertx vertx)
+      throws Throwable {
+    verifyAsync(fileName, execution, testContext, vertx.getDelegate());
+  }
+
+  public static void verifyAsync(String fileName, Consumer<JsonObject> execution,
+      VertxTestContext testContext, Vertx vertx)
+      throws Throwable {
+    Handler<AsyncResult<JsonObject>> configHandler = testContext
+        .succeeding(config -> testContext.verify(() -> {
+          execution.accept(config);
+        }));
+    fromHOCON(fileName, vertx, configHandler);
+
+    Assertions.assertTrue(testContext.awaitCompletion(5, TimeUnit.MINUTES));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+  private static void fromHOCON(String fileName, Vertx vertx,
+      Handler<AsyncResult<JsonObject>> configHandler) {
+    ConfigRetrieverOptions options = new ConfigRetrieverOptions();
+    options.addStore(new ConfigStoreOptions()
+        .setType("file")
+        .setFormat("hocon")
+        .setConfig(new JsonObject().put("path", fileName)));
+
+    ConfigRetriever retriever = ConfigRetriever.create(vertx, options);
+    retriever.getConfig(configHandler);
+  }
+
+}

--- a/src/test/java/io/knotx/junit5/util/HoconLoaderTest.java
+++ b/src/test/java/io/knotx/junit5/util/HoconLoaderTest.java
@@ -1,0 +1,58 @@
+package io.knotx.junit5.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+class HoconLoaderTest {
+
+  @Test
+  void testNotExistingFile(Vertx vertx) {
+    try {
+      HoconLoader.verify("config/not-defined.conf",
+          json -> fail("Expect file not found exception!"), vertx);
+    } catch (Throwable e) {
+      // expected
+    }
+  }
+
+  @Test
+  void testExistingFile(Vertx vertx) throws Throwable {
+    HoconLoader.verify("config/modules_config.conf",
+        json -> assertEquals("io.knotx.junit5.util.TestConfigurationHttpServer",
+            json.getJsonObject("modules").getString("server")), vertx);
+  }
+
+  @Test
+  void testExistingFile(io.vertx.reactivex.core.Vertx vertx)
+      throws Throwable {
+    HoconLoader.verify("config/modules_config.conf",
+        json -> assertEquals("io.knotx.junit5.util.TestConfigurationHttpServer",
+            json.getJsonObject("modules").getString("server")), vertx);
+  }
+
+  @Test
+  void testExistingFileAsync(Vertx vertx, VertxTestContext testContext) throws Throwable {
+    HoconLoader.verifyAsync("config/modules_config.conf", json -> {
+      assertEquals("io.knotx.junit5.util.TestConfigurationHttpServer",
+          json.getJsonObject("modules").getString("server"));
+      testContext.completeNow();
+    }, testContext, vertx);
+  }
+
+  @Test
+  void testExistingFileAsync(io.vertx.reactivex.core.Vertx vertx, VertxTestContext testContext)
+      throws Throwable {
+    HoconLoader.verifyAsync("config/modules_config.conf", json -> {
+      assertEquals("io.knotx.junit5.util.TestConfigurationHttpServer",
+          json.getJsonObject("modules").getString("server"));
+      testContext.completeNow();
+    }, testContext, vertx);
+  }
+}

--- a/src/test/java/io/knotx/junit5/util/HoconLoaderTest.java
+++ b/src/test/java/io/knotx/junit5/util/HoconLoaderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.knotx.junit5.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
Fragments modules refactor: Knotx/knotx-fragments#154. Move `HoconLoader` from `Knot.x Fragments` to `Knot.x JUnit5`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
