### PR TITLE
knotx/knotx-fragments#219 update wiremock dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
     implementation(group = "org.junit.jupiter", name = "junit-jupiter-migrationsupport")
     implementation(group = "org.mockito", name = "mockito-core")
     implementation(group = "org.mockito", name = "mockito-junit-jupiter")
-    implementation(group = "com.github.tomakehurst", name = "wiremock")
+    implementation(group = "com.github.tomakehurst", name = "wiremock-jre8")
     implementation(group = "commons-io", name = "commons-io")
     implementation(group = "org.jsoup", name = "jsoup", version = "1.11.2")
 


### PR DESCRIPTION
Fixes knotx/knotx-fragments#219.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
